### PR TITLE
Add AI Agent Deck for money management

### DIFF
--- a/agents.css
+++ b/agents.css
@@ -1,0 +1,462 @@
+.agents-body {
+    background: radial-gradient(ellipse at top, #0a1a2e 0%, #000 70%);
+    color: #d6f2ff;
+    min-height: 100vh;
+    overflow: auto;
+    -webkit-user-select: auto;
+    user-select: auto;
+    font-family: "SF Pro Display", "Helvetica Neue", -apple-system, sans-serif;
+}
+
+.deck-header {
+    padding: 20px 24px 8px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 12px;
+    border-bottom: 1px solid rgba(127, 200, 255, 0.15);
+}
+.back-link {
+    color: #7fa9d8;
+    text-decoration: none;
+    font-size: 12px;
+    letter-spacing: 2px;
+    font-family: "SF Mono", monospace;
+}
+.back-link:hover { color: #6ed4ff; }
+.deck-header h1 {
+    font-weight: 200;
+    letter-spacing: 8px;
+    color: #6ed4ff;
+    font-size: 20px;
+    text-shadow: 0 0 16px rgba(110, 212, 255, 0.4);
+}
+.deck-stats { display: flex; gap: 18px; }
+.stat {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    font-family: "SF Mono", monospace;
+}
+.stat-label {
+    font-size: 9px;
+    color: #5e7c9c;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+}
+.stat span:last-child {
+    color: #3afcaa;
+    font-size: 16px;
+    font-weight: 500;
+}
+
+.deck-tabs {
+    display: flex;
+    gap: 4px;
+    padding: 12px 24px;
+    border-bottom: 1px solid rgba(127, 200, 255, 0.1);
+    overflow-x: auto;
+}
+.tab {
+    background: transparent;
+    border: 1px solid rgba(127, 169, 216, 0.2);
+    color: #7fa9d8;
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-size: 12px;
+    letter-spacing: 1px;
+    cursor: pointer;
+    font-family: inherit;
+    white-space: nowrap;
+    transition: all 0.15s;
+}
+.tab:hover { border-color: #6ed4ff; color: #6ed4ff; }
+.tab.active {
+    background: rgba(110, 212, 255, 0.15);
+    border-color: #6ed4ff;
+    color: #6ed4ff;
+}
+
+.deck-main { padding: 24px; max-width: 1200px; margin: 0 auto; }
+.tab-panel { display: none; }
+.tab-panel.active { display: block; animation: fade 0.3s; }
+@keyframes fade { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+
+.agent-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 16px;
+}
+.agent-card {
+    background: linear-gradient(135deg, rgba(15, 30, 55, 0.6), rgba(5, 15, 30, 0.6));
+    border: 1px solid rgba(127, 200, 255, 0.2);
+    border-radius: 14px;
+    padding: 18px;
+    cursor: pointer;
+    transition: all 0.2s;
+    position: relative;
+    overflow: hidden;
+}
+.agent-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(110, 212, 255, 0.08), transparent 50%);
+    pointer-events: none;
+}
+.agent-card:hover {
+    border-color: #6ed4ff;
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px rgba(110, 212, 255, 0.12);
+}
+.agent-icon {
+    font-size: 28px;
+    margin-bottom: 10px;
+}
+.agent-name {
+    font-size: 15px;
+    font-weight: 500;
+    color: #e6f1ff;
+    letter-spacing: 1px;
+    margin-bottom: 6px;
+}
+.agent-tagline {
+    font-size: 12px;
+    color: #7fa9d8;
+    line-height: 1.5;
+    margin-bottom: 12px;
+}
+.agent-meta {
+    display: flex;
+    justify-content: space-between;
+    font-size: 10px;
+    color: #5e7c9c;
+    letter-spacing: 1px;
+    font-family: "SF Mono", monospace;
+}
+.agent-runs { color: #3afcaa; }
+
+/* Modal */
+.modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.85);
+    backdrop-filter: blur(12px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+    padding: 20px;
+    transition: opacity 0.2s;
+}
+.modal.hidden { opacity: 0; pointer-events: none; }
+.modal-panel {
+    width: min(100%, 680px);
+    max-height: 90vh;
+    background: linear-gradient(to bottom, #0a1525, #050a14);
+    border: 1px solid rgba(127, 200, 255, 0.3);
+    border-radius: 16px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+.modal-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 18px 22px;
+    border-bottom: 1px solid rgba(127, 200, 255, 0.15);
+}
+.modal-head h2 {
+    font-weight: 300;
+    letter-spacing: 2px;
+    color: #6ed4ff;
+    font-size: 18px;
+}
+#modal-close {
+    background: transparent;
+    border: none;
+    color: #7fa9d8;
+    font-size: 20px;
+    cursor: pointer;
+    padding: 4px 10px;
+}
+#modal-close:hover { color: #6ed4ff; }
+.modal-body { padding: 20px 22px; overflow-y: auto; }
+.agent-desc { color: #8bb4e0; font-size: 13px; line-height: 1.6; margin-bottom: 16px; }
+.modal-label {
+    display: block;
+    font-size: 12px;
+    color: #7fa9d8;
+    letter-spacing: 1px;
+    margin-bottom: 14px;
+}
+.modal-label textarea,
+.modal-label input,
+.modal-label select {
+    display: block;
+    width: 100%;
+    margin-top: 6px;
+    padding: 10px 12px;
+    background: rgba(10, 25, 45, 0.6);
+    border: 1px solid rgba(127, 169, 216, 0.25);
+    border-radius: 8px;
+    color: #e6f1ff;
+    font-size: 14px;
+    font-family: inherit;
+    outline: none;
+    resize: vertical;
+}
+.modal-label textarea:focus,
+.modal-label input:focus { border-color: #6ed4ff; }
+.modal-actions {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    margin-bottom: 14px;
+}
+#modal-status { font-size: 12px; color: #7fa9d8; font-family: "SF Mono", monospace; }
+.modal-result {
+    background: rgba(10, 25, 45, 0.5);
+    border-left: 2px solid #6ed4ff;
+    padding: 14px 16px;
+    border-radius: 6px;
+    font-size: 13px;
+    line-height: 1.7;
+    color: #d6f2ff;
+    white-space: pre-wrap;
+    max-height: 50vh;
+    overflow-y: auto;
+    display: none;
+}
+.modal-result.show { display: block; }
+.modal-result h3, .modal-result h4 { color: #6ed4ff; margin: 10px 0 6px; font-weight: 500; }
+.modal-result ul, .modal-result ol { padding-left: 20px; margin: 6px 0; }
+.modal-result code {
+    background: rgba(110, 212, 255, 0.1);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 12px;
+}
+
+/* Buttons */
+button {
+    padding: 10px 18px;
+    background: rgba(110, 212, 255, 0.15);
+    border: 1px solid rgba(110, 212, 255, 0.4);
+    color: #6ed4ff;
+    border-radius: 8px;
+    font-size: 13px;
+    letter-spacing: 1px;
+    cursor: pointer;
+    font-family: inherit;
+    transition: all 0.15s;
+}
+button:hover { background: rgba(110, 212, 255, 0.25); }
+button:active { transform: scale(0.97); }
+button:disabled { opacity: 0.4; cursor: not-allowed; }
+button.danger {
+    background: rgba(255, 77, 109, 0.12);
+    border-color: rgba(255, 77, 109, 0.4);
+    color: #ff8aa0;
+}
+button.danger:hover { background: rgba(255, 77, 109, 0.22); }
+
+/* Vault */
+.vault-toolbar, .revenue-form, .plan-toolbar {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 18px;
+    flex-wrap: wrap;
+}
+.vault-toolbar input, .revenue-form input, .revenue-form select {
+    flex: 1;
+    min-width: 160px;
+    padding: 10px 14px;
+    background: rgba(10, 25, 45, 0.6);
+    border: 1px solid rgba(127, 169, 216, 0.25);
+    border-radius: 8px;
+    color: #e6f1ff;
+    font-size: 14px;
+    font-family: inherit;
+    outline: none;
+}
+.vault-toolbar input:focus, .revenue-form input:focus { border-color: #6ed4ff; }
+
+.vault-list, .revenue-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+.vault-item, .revenue-item {
+    background: rgba(15, 30, 55, 0.5);
+    border: 1px solid rgba(127, 200, 255, 0.15);
+    border-radius: 10px;
+    padding: 14px 16px;
+}
+.vault-item-head, .revenue-item-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 6px;
+    gap: 10px;
+}
+.vault-agent {
+    font-size: 11px;
+    color: #6ed4ff;
+    letter-spacing: 1px;
+    font-family: "SF Mono", monospace;
+}
+.vault-date {
+    font-size: 10px;
+    color: #5e7c9c;
+    font-family: "SF Mono", monospace;
+}
+.vault-brief {
+    font-size: 12px;
+    color: #8bb4e0;
+    font-style: italic;
+    margin-bottom: 8px;
+}
+.vault-content {
+    font-size: 13px;
+    line-height: 1.6;
+    color: #d6f2ff;
+    white-space: pre-wrap;
+    max-height: 200px;
+    overflow-y: auto;
+}
+.vault-actions {
+    display: flex;
+    gap: 6px;
+    margin-top: 8px;
+}
+.vault-actions button {
+    padding: 5px 10px;
+    font-size: 11px;
+}
+
+/* Revenue */
+.revenue-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 12px;
+    margin-bottom: 18px;
+}
+.sum-card {
+    background: linear-gradient(135deg, rgba(58, 252, 170, 0.08), rgba(58, 252, 170, 0.02));
+    border: 1px solid rgba(58, 252, 170, 0.25);
+    border-radius: 10px;
+    padding: 14px 16px;
+}
+.sum-label { font-size: 10px; color: #7fa9d8; letter-spacing: 2px; text-transform: uppercase; }
+.sum-value { font-size: 22px; color: #3afcaa; margin-top: 4px; font-family: "SF Mono", monospace; }
+.progress-bar {
+    margin-top: 10px;
+    height: 6px;
+    background: rgba(58, 252, 170, 0.1);
+    border-radius: 3px;
+    overflow: hidden;
+}
+.progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #3afcaa, #6ed4ff);
+    transition: width 0.4s;
+}
+.revenue-amount {
+    color: #3afcaa;
+    font-family: "SF Mono", monospace;
+    font-weight: 500;
+}
+.revenue-source { color: #e6f1ff; font-size: 14px; }
+.revenue-meta { font-size: 11px; color: #7fa9d8; margin-top: 4px; }
+.revenue-del {
+    background: transparent;
+    border: none;
+    color: #5e7c9c;
+    font-size: 14px;
+    padding: 0 6px;
+    cursor: pointer;
+}
+.revenue-del:hover { color: #ff8aa0; }
+
+/* Config */
+.config-card {
+    max-width: 560px;
+    background: linear-gradient(to bottom, #0a1525, #050a14);
+    border: 1px solid rgba(127, 200, 255, 0.2);
+    border-radius: 14px;
+    padding: 24px 22px;
+}
+.config-card h2 {
+    font-weight: 300;
+    letter-spacing: 3px;
+    color: #6ed4ff;
+    margin-bottom: 18px;
+    font-size: 16px;
+}
+.config-card label {
+    display: block;
+    font-size: 12px;
+    color: #7fa9d8;
+    letter-spacing: 1px;
+    margin-bottom: 14px;
+}
+.config-card input, .config-card select, .config-card textarea {
+    display: block;
+    width: 100%;
+    margin-top: 6px;
+    padding: 10px 12px;
+    background: rgba(10, 25, 45, 0.6);
+    border: 1px solid rgba(127, 169, 216, 0.25);
+    border-radius: 8px;
+    color: #e6f1ff;
+    font-size: 14px;
+    font-family: inherit;
+    outline: none;
+    resize: vertical;
+}
+.config-card input:focus, .config-card textarea:focus { border-color: #6ed4ff; }
+.help-text { font-size: 11px; color: #5e7c9c; line-height: 1.6; margin-top: 12px; }
+.btn-row { display: flex; gap: 10px; margin-top: 4px; }
+.btn-row button { flex: 1; }
+
+.plan-output {
+    background: rgba(15, 30, 55, 0.5);
+    border: 1px solid rgba(127, 200, 255, 0.15);
+    border-radius: 12px;
+    padding: 20px;
+    font-size: 14px;
+    line-height: 1.7;
+    color: #d6f2ff;
+    white-space: pre-wrap;
+    min-height: 200px;
+}
+.plan-output:empty::before {
+    content: "Klik 'Generér ugeplan' for at få alle agenter til at koordinere en plan for denne uge.";
+    color: #5e7c9c;
+    font-style: italic;
+}
+.plan-output h3 { color: #6ed4ff; margin: 14px 0 6px; font-weight: 500; font-size: 15px; }
+.plan-output ul, .plan-output ol { padding-left: 22px; margin: 6px 0; }
+
+#plan-status { font-size: 12px; color: #7fa9d8; font-family: "SF Mono", monospace; }
+
+.empty-state {
+    text-align: center;
+    padding: 40px 20px;
+    color: #5e7c9c;
+    font-style: italic;
+    font-size: 13px;
+}
+
+@media (max-width: 640px) {
+    .deck-header h1 { font-size: 16px; letter-spacing: 5px; }
+    .deck-stats { gap: 10px; }
+    .stat span:last-child { font-size: 13px; }
+    .deck-main { padding: 14px; }
+    .agent-grid { grid-template-columns: 1fr; }
+    .revenue-form, .vault-toolbar { flex-direction: column; }
+    .revenue-form input, .vault-toolbar input { min-width: 0; }
+}

--- a/agents.html
+++ b/agents.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Agent Deck — Money Management</title>
+    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="agents.css">
+</head>
+<body class="agents-body">
+    <header class="deck-header">
+        <a href="index.html" class="back-link">← JARVIS</a>
+        <h1>AGENT&nbsp;DECK</h1>
+        <div class="deck-stats">
+            <span class="stat"><span class="stat-label">Optjent</span><span id="stat-earned">0 kr</span></span>
+            <span class="stat"><span class="stat-label">Pipeline</span><span id="stat-pipeline">0 kr</span></span>
+            <span class="stat"><span class="stat-label">Idéer</span><span id="stat-ideas">0</span></span>
+        </div>
+    </header>
+
+    <nav class="deck-tabs">
+        <button class="tab active" data-tab="agents">Agenter</button>
+        <button class="tab" data-tab="vault">Idévault</button>
+        <button class="tab" data-tab="revenue">Indtægter</button>
+        <button class="tab" data-tab="plan">Ugeplan</button>
+        <button class="tab" data-tab="config">Opsæt</button>
+    </nav>
+
+    <main class="deck-main">
+        <section class="tab-panel active" id="panel-agents">
+            <div class="agent-grid" id="agent-grid"></div>
+        </section>
+
+        <section class="tab-panel" id="panel-vault">
+            <div class="vault-toolbar">
+                <input type="text" id="vault-search" placeholder="Søg i idéer…">
+                <button id="vault-export">Eksportér JSON</button>
+                <button id="vault-clear" class="danger">Ryd alt</button>
+            </div>
+            <div class="vault-list" id="vault-list"></div>
+        </section>
+
+        <section class="tab-panel" id="panel-revenue">
+            <div class="revenue-form">
+                <input type="text" id="rev-source" placeholder="Kilde (fx freelance-gig, produkt)">
+                <input type="number" id="rev-amount" placeholder="Beløb (kr)" step="0.01">
+                <select id="rev-agent"></select>
+                <button id="rev-add">Log indtægt</button>
+            </div>
+            <div class="revenue-summary" id="revenue-summary"></div>
+            <div class="revenue-list" id="revenue-list"></div>
+        </section>
+
+        <section class="tab-panel" id="panel-plan">
+            <div class="plan-toolbar">
+                <button id="plan-generate">Generér ugeplan med alle agenter</button>
+                <span id="plan-status"></span>
+            </div>
+            <div class="plan-output" id="plan-output"></div>
+        </section>
+
+        <section class="tab-panel" id="panel-config">
+            <div class="config-card">
+                <h2>API &amp; Profil</h2>
+                <label>Anthropic API-nøgle
+                    <input type="password" id="cfg-api-key" placeholder="sk-ant-…">
+                </label>
+                <label>Model
+                    <select id="cfg-model">
+                        <option value="claude-haiku-4-5-20251001">Haiku 4.5 (hurtig/billig)</option>
+                        <option value="claude-sonnet-4-6">Sonnet 4.6 (balance)</option>
+                        <option value="claude-opus-4-7">Opus 4.7 (smartest)</option>
+                    </select>
+                </label>
+                <label>Din niche / mål
+                    <textarea id="cfg-niche" rows="3" placeholder="Fx: Jeg er udvikler med 2 timer om dagen. Vil tjene 5000 kr/md ekstra. Interesse: AI-værktøjer, webudvikling."></textarea>
+                </label>
+                <label>Månedligt mål (kr)
+                    <input type="number" id="cfg-goal" placeholder="5000">
+                </label>
+                <label>Valuta-symbol
+                    <input type="text" id="cfg-currency" placeholder="kr" maxlength="4">
+                </label>
+                <div class="btn-row">
+                    <button id="cfg-save">Gem</button>
+                    <button id="cfg-reset" class="danger">Nulstil alt</button>
+                </div>
+                <p class="help-text">Data gemmes kun i din browser. API-nøglen forlader aldrig din enhed undtagen til Anthropic.</p>
+            </div>
+        </section>
+    </main>
+
+    <div class="modal hidden" id="modal">
+        <div class="modal-panel">
+            <div class="modal-head">
+                <h2 id="modal-title">Agent</h2>
+                <button id="modal-close">✕</button>
+            </div>
+            <div class="modal-body">
+                <p id="modal-desc" class="agent-desc"></p>
+                <label class="modal-label">Brief til agenten
+                    <textarea id="modal-brief" rows="4" placeholder="Beskriv hvad du vil have — eller lad feltet stå tomt for default-opgave."></textarea>
+                </label>
+                <div class="modal-actions">
+                    <button id="modal-run">Kør agent</button>
+                    <span id="modal-status"></span>
+                </div>
+                <div class="modal-result" id="modal-result"></div>
+            </div>
+        </div>
+    </div>
+
+    <script src="agents.js"></script>
+</body>
+</html>

--- a/agents.js
+++ b/agents.js
@@ -1,0 +1,530 @@
+(() => {
+    "use strict";
+
+    const STORAGE_KEY = "agent-deck.v1";
+    const JARVIS_KEY = "jarvis.v4";
+
+    const AGENTS = [
+        {
+            id: "content",
+            icon: "✍️",
+            name: "Content Creator",
+            tagline: "Skriver blogindlæg, LinkedIn-posts og tråde der driver trafik til tilbud.",
+            defaultBrief: "Skriv 3 LinkedIn-posts og 1 blogindlægs-outline, der kan drive leads til min niche.",
+            system: `You are a senior content strategist specialising in building personal brands that generate real revenue. You produce: hook-driven LinkedIn posts, X/Twitter threads, blog outlines, newsletter intros. Every piece must have a clear conversion angle (signup, DM, product link). Use short paragraphs, strong hooks in line 1, no filler. Output ready-to-publish drafts in Danish unless user writes in English.`
+        },
+        {
+            id: "market",
+            icon: "📊",
+            name: "Market Researcher",
+            tagline: "Finder profitable nicher, underserverede målgrupper og trending keywords.",
+            defaultBrief: "Find 5 undersold micro-nicher jeg kan angribe nu, med konkret evidens for efterspørgsel.",
+            system: `You are a market research analyst. Identify underserved niches, validated demand signals (reddit threads, niche subreddits, communities, search trends, marketplaces with paying customers). Give specific evidence: community names, forum threads, paid product examples, pricing. Rank by: ease of entry, revenue potential, competition. Be concrete, no fluff. Output in Danish.`
+        },
+        {
+            id: "freelance",
+            icon: "💼",
+            name: "Freelance Hunter",
+            tagline: "Finder konkrete gigs, pitch-templates og outreach-beskeder.",
+            defaultBrief: "Giv mig 5 gig-typer jeg kan sælge i næste uge, med kolde DM-templates.",
+            system: `You are a freelance sales coach. Propose specific gig types a solo operator can deliver in under a week, with:
+- exact deliverable
+- realistic price range (DKK/EUR)
+- where to find clients (platforms, communities, cold outreach)
+- ready-to-copy outreach DM/email template (Danish)
+- red flags to avoid
+Be tactical and ready-to-execute today. Output in Danish.`
+        },
+        {
+            id: "copy",
+            icon: "🎯",
+            name: "Copywriter",
+            tagline: "Højkonverterende sales-copy, landing pages, ads og email-sekvenser.",
+            defaultBrief: "Skriv landing page headline + subhead + 3 bullets + CTA for mit tilbud.",
+            system: `You are a direct-response copywriter in the tradition of Hopkins, Kennedy, Halbert. Structure: big promise headline, urgent subhead, bullet-benefits (feature→benefit→outcome), proof, CTA. Match the reader's internal monologue. Tight, specific, no generic adjectives. Output ready-to-paste copy in Danish.`
+        },
+        {
+            id: "product",
+            icon: "💡",
+            name: "Product Ideator",
+            tagline: "Konkrete digitale produkt- og SaaS-idéer baseret på din niche.",
+            defaultBrief: "Giv mig 5 digitale produkter jeg kan bygge solo på <14 dage og sælge for 200-2000 kr.",
+            system: `You are a product strategist specialising in small digital products (templates, notion systems, mini-SaaS, scripts, prompt packs, paid newsletters, short courses). For each idea include:
+- one-line value prop
+- who exactly buys this
+- realistic pricing
+- time-to-MVP
+- first 3 distribution channels
+Favour ideas that can be built solo in under 2 weeks. Output in Danish.`
+        },
+        {
+            id: "seo",
+            icon: "🔍",
+            name: "SEO Strategist",
+            tagline: "Keyword-clusters, content-pillar-plan og link-strategi for organisk vækst.",
+            defaultBrief: "Lav et 10-ugers SEO content-plan for min niche med keyword-clusters og interne links.",
+            system: `You are an SEO strategist. Produce: keyword clusters (pillar + cluster pages), search intent per keyword, monthly volume estimate category (low/med/high), content format, internal linking map, quick-win keywords (low competition). Output a structured plan in Danish.`
+        },
+        {
+            id: "automator",
+            icon: "⚙️",
+            name: "Automation Finder",
+            tagline: "Finder manuelle opgaver du kan automatisere og sælge som service eller script.",
+            defaultBrief: "Find 5 manuelle business-tasks jeg kan automatisere og sælge som månedsservice.",
+            system: `You are an automation consultant. Find real, boring, repetitive business tasks that small companies pay to get done (lead scraping, invoice processing, data entry, reporting, social media scheduling, email parsing). For each: target customer, current pain, automation stack (no-code/Python/API), price as DIY script vs monthly retainer. Output in Danish.`
+        },
+        {
+            id: "strategy",
+            icon: "🧭",
+            name: "Strategy Director",
+            tagline: "Prioriterer hvad du skal lave NU for maks afkast på din tid.",
+            defaultBrief: "Baseret på min profil, hvad skal jeg fokusere 100% på i næste 30 dage?",
+            system: `You are a ruthless strategy director. Given a solo operator's constraints, cut everything except the 1-2 highest-leverage activities for the next 30 days. Give:
+- THE focus (one sentence)
+- why (leverage, ease, speed to revenue)
+- week-by-week milestones
+- what to NOT do
+Brutally honest, no motivational fluff. Output in Danish.`
+        }
+    ];
+
+    const DEFAULT_STATE = {
+        apiKey: "",
+        model: "claude-sonnet-4-6",
+        niche: "",
+        goal: 5000,
+        currency: "kr",
+        runs: {}, // agentId -> count
+        vault: [], // { id, agentId, brief, content, date }
+        revenue: [], // { id, source, amount, agentId, date }
+        plans: [] // { date, content }
+    };
+
+    function load() {
+        try {
+            const raw = localStorage.getItem(STORAGE_KEY);
+            if (raw) return { ...DEFAULT_STATE, ...JSON.parse(raw) };
+        } catch (_) {}
+        // Try to inherit API key from jarvis
+        try {
+            const jarvis = JSON.parse(localStorage.getItem(JARVIS_KEY) || "{}");
+            if (jarvis.apiKey) return { ...DEFAULT_STATE, apiKey: jarvis.apiKey, model: jarvis.model || DEFAULT_STATE.model };
+        } catch (_) {}
+        return { ...DEFAULT_STATE };
+    }
+    function save() { localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); }
+    const state = load();
+
+    const $ = (s) => document.querySelector(s);
+    const $$ = (s) => document.querySelectorAll(s);
+    const uid = () => Math.random().toString(36).slice(2, 10);
+    const fmt = (n) => new Intl.NumberFormat("da-DK", { maximumFractionDigits: 0 }).format(n) + " " + state.currency;
+
+    // ---------- Tabs ----------
+    $$(".tab").forEach(t => t.addEventListener("click", () => {
+        $$(".tab").forEach(x => x.classList.remove("active"));
+        $$(".tab-panel").forEach(x => x.classList.remove("active"));
+        t.classList.add("active");
+        $("#panel-" + t.dataset.tab).classList.add("active");
+    }));
+
+    // ---------- Agent grid ----------
+    function renderAgents() {
+        const grid = $("#agent-grid");
+        grid.innerHTML = AGENTS.map(a => `
+            <div class="agent-card" data-id="${a.id}">
+                <div class="agent-icon">${a.icon}</div>
+                <div class="agent-name">${a.name}</div>
+                <div class="agent-tagline">${a.tagline}</div>
+                <div class="agent-meta">
+                    <span>KØRT</span>
+                    <span class="agent-runs">${state.runs[a.id] || 0}×</span>
+                </div>
+            </div>
+        `).join("");
+        grid.querySelectorAll(".agent-card").forEach(el => {
+            el.addEventListener("click", () => openAgent(el.dataset.id));
+        });
+    }
+
+    // ---------- Modal ----------
+    let currentAgent = null;
+    function openAgent(id) {
+        const a = AGENTS.find(x => x.id === id);
+        if (!a) return;
+        currentAgent = a;
+        $("#modal-title").textContent = `${a.icon}  ${a.name}`;
+        $("#modal-desc").textContent = a.tagline;
+        $("#modal-brief").value = "";
+        $("#modal-brief").placeholder = a.defaultBrief;
+        $("#modal-result").classList.remove("show");
+        $("#modal-result").innerHTML = "";
+        $("#modal-status").textContent = "";
+        $("#modal").classList.remove("hidden");
+    }
+    $("#modal-close").addEventListener("click", () => $("#modal").classList.add("hidden"));
+    $("#modal").addEventListener("click", (e) => { if (e.target.id === "modal") $("#modal").classList.add("hidden"); });
+
+    $("#modal-run").addEventListener("click", async () => {
+        if (!currentAgent) return;
+        const brief = $("#modal-brief").value.trim() || currentAgent.defaultBrief;
+        const btn = $("#modal-run");
+        const status = $("#modal-status");
+        const result = $("#modal-result");
+
+        if (!state.apiKey) {
+            status.textContent = "⚠ Tilføj API-nøgle under Opsæt.";
+            return;
+        }
+
+        btn.disabled = true;
+        status.textContent = "agent kører…";
+        result.classList.remove("show");
+        result.innerHTML = "";
+
+        try {
+            const content = await runAgent(currentAgent, brief);
+            result.innerHTML = renderMarkdown(content);
+            result.classList.add("show");
+            state.runs[currentAgent.id] = (state.runs[currentAgent.id] || 0) + 1;
+            state.vault.unshift({
+                id: uid(),
+                agentId: currentAgent.id,
+                brief,
+                content,
+                date: new Date().toISOString()
+            });
+            save();
+            renderAgents();
+            renderVault();
+            renderStats();
+            status.textContent = "✓ gemt i idévault";
+        } catch (err) {
+            console.error(err);
+            status.textContent = "✗ fejl: " + err.message;
+        } finally {
+            btn.disabled = false;
+        }
+    });
+
+    // ---------- Claude API ----------
+    async function runAgent(agent, brief) {
+        const context = state.niche ? `\n\nBrugerens kontekst og mål:\n${state.niche}\n\nMånedligt indtægtsmål: ${state.goal} ${state.currency}.` : "";
+        const system = agent.system + context;
+
+        const res = await fetch("https://api.anthropic.com/v1/messages", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "x-api-key": state.apiKey,
+                "anthropic-version": "2023-06-01",
+                "anthropic-dangerous-direct-browser-access": "true"
+            },
+            body: JSON.stringify({
+                model: state.model,
+                max_tokens: 2000,
+                system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
+                messages: [{ role: "user", content: brief }]
+            })
+        });
+
+        if (!res.ok) {
+            const err = await res.text();
+            throw new Error(`API ${res.status}: ${err.slice(0, 200)}`);
+        }
+        const data = await res.json();
+        return data.content.map(b => b.text || "").join("\n").trim();
+    }
+
+    // ---------- Markdown (minimal, safe) ----------
+    function escapeHtml(s) {
+        return s.replace(/[&<>"']/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]);
+    }
+    function renderMarkdown(md) {
+        let s = escapeHtml(md);
+        s = s.replace(/^### (.+)$/gm, "<h4>$1</h4>");
+        s = s.replace(/^## (.+)$/gm, "<h3>$1</h3>");
+        s = s.replace(/^# (.+)$/gm, "<h3>$1</h3>");
+        s = s.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+        s = s.replace(/\*(.+?)\*/g, "<em>$1</em>");
+        s = s.replace(/`([^`]+)`/g, "<code>$1</code>");
+        // Lists
+        s = s.replace(/^(?:[-*] .+(?:\n|$))+/gm, block => {
+            const items = block.trim().split("\n").map(l => "<li>" + l.replace(/^[-*]\s+/, "") + "</li>").join("");
+            return "<ul>" + items + "</ul>";
+        });
+        s = s.replace(/^(?:\d+\. .+(?:\n|$))+/gm, block => {
+            const items = block.trim().split("\n").map(l => "<li>" + l.replace(/^\d+\.\s+/, "") + "</li>").join("");
+            return "<ol>" + items + "</ol>";
+        });
+        s = s.replace(/\n\n+/g, "<br><br>");
+        s = s.replace(/\n/g, "<br>");
+        return s;
+    }
+
+    // ---------- Vault ----------
+    function renderVault() {
+        const list = $("#vault-list");
+        const q = ($("#vault-search").value || "").toLowerCase();
+        const items = state.vault.filter(v => {
+            if (!q) return true;
+            return (v.content + " " + v.brief).toLowerCase().includes(q);
+        });
+        if (!items.length) {
+            list.innerHTML = `<div class="empty-state">Ingen idéer endnu. Kør en agent på fanen "Agenter".</div>`;
+            return;
+        }
+        list.innerHTML = items.map(v => {
+            const agent = AGENTS.find(a => a.id === v.agentId);
+            return `
+            <div class="vault-item" data-id="${v.id}">
+                <div class="vault-item-head">
+                    <span class="vault-agent">${agent ? agent.icon + " " + agent.name : v.agentId}</span>
+                    <span class="vault-date">${new Date(v.date).toLocaleString("da-DK")}</span>
+                </div>
+                <div class="vault-brief">Brief: ${escapeHtml(v.brief)}</div>
+                <div class="vault-content">${renderMarkdown(v.content)}</div>
+                <div class="vault-actions">
+                    <button data-act="copy">Kopiér</button>
+                    <button data-act="del" class="danger">Slet</button>
+                </div>
+            </div>`;
+        }).join("");
+
+        list.querySelectorAll(".vault-item").forEach(el => {
+            const id = el.dataset.id;
+            el.querySelector('[data-act="copy"]').addEventListener("click", () => {
+                const item = state.vault.find(v => v.id === id);
+                navigator.clipboard.writeText(item.content).then(() => {
+                    el.querySelector('[data-act="copy"]').textContent = "Kopieret ✓";
+                    setTimeout(() => { el.querySelector('[data-act="copy"]').textContent = "Kopiér"; }, 1500);
+                });
+            });
+            el.querySelector('[data-act="del"]').addEventListener("click", () => {
+                if (!confirm("Slet denne idé?")) return;
+                state.vault = state.vault.filter(v => v.id !== id);
+                save();
+                renderVault();
+                renderStats();
+            });
+        });
+    }
+    $("#vault-search").addEventListener("input", renderVault);
+    $("#vault-export").addEventListener("click", () => {
+        const blob = new Blob([JSON.stringify(state.vault, null, 2)], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `agent-vault-${new Date().toISOString().slice(0, 10)}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+    });
+    $("#vault-clear").addEventListener("click", () => {
+        if (!confirm("Slet ALLE idéer i vaulten? Kan ikke fortrydes.")) return;
+        state.vault = [];
+        save();
+        renderVault();
+        renderStats();
+    });
+
+    // ---------- Revenue ----------
+    function renderRevenueAgentSelect() {
+        const sel = $("#rev-agent");
+        sel.innerHTML = `<option value="">Uden agent</option>` +
+            AGENTS.map(a => `<option value="${a.id}">${a.icon} ${a.name}</option>`).join("");
+    }
+
+    function renderRevenue() {
+        const list = $("#revenue-list");
+        const sum = $("#revenue-summary");
+
+        const total = state.revenue.reduce((s, r) => s + r.amount, 0);
+        const now = new Date();
+        const monthTotal = state.revenue
+            .filter(r => {
+                const d = new Date(r.date);
+                return d.getFullYear() === now.getFullYear() && d.getMonth() === now.getMonth();
+            })
+            .reduce((s, r) => s + r.amount, 0);
+        const goal = state.goal || 0;
+        const pct = goal > 0 ? Math.min(100, Math.round(monthTotal / goal * 100)) : 0;
+
+        sum.innerHTML = `
+            <div class="sum-card">
+                <div class="sum-label">Total optjent</div>
+                <div class="sum-value">${fmt(total)}</div>
+            </div>
+            <div class="sum-card">
+                <div class="sum-label">Denne måned</div>
+                <div class="sum-value">${fmt(monthTotal)}</div>
+                ${goal > 0 ? `<div class="progress-bar"><div class="progress-fill" style="width:${pct}%"></div></div>
+                <div style="font-size:11px;color:#7fa9d8;margin-top:4px;">${pct}% af mål (${fmt(goal)})</div>` : ""}
+            </div>
+            <div class="sum-card">
+                <div class="sum-label">Indtægter</div>
+                <div class="sum-value">${state.revenue.length}</div>
+            </div>
+        `;
+
+        if (!state.revenue.length) {
+            list.innerHTML = `<div class="empty-state">Ingen indtægter logget endnu. Log din første over.</div>`;
+            return;
+        }
+        const sorted = [...state.revenue].sort((a, b) => new Date(b.date) - new Date(a.date));
+        list.innerHTML = sorted.map(r => {
+            const agent = AGENTS.find(a => a.id === r.agentId);
+            return `
+            <div class="revenue-item" data-id="${r.id}">
+                <div class="revenue-item-head">
+                    <span class="revenue-source">${escapeHtml(r.source)}</span>
+                    <span class="revenue-amount">+${fmt(r.amount)}</span>
+                </div>
+                <div class="revenue-meta">
+                    ${new Date(r.date).toLocaleDateString("da-DK")}
+                    ${agent ? " · " + agent.icon + " " + agent.name : ""}
+                    <button class="revenue-del" data-id="${r.id}" title="Slet">✕</button>
+                </div>
+            </div>`;
+        }).join("");
+
+        list.querySelectorAll(".revenue-del").forEach(btn => {
+            btn.addEventListener("click", () => {
+                state.revenue = state.revenue.filter(r => r.id !== btn.dataset.id);
+                save();
+                renderRevenue();
+                renderStats();
+            });
+        });
+    }
+
+    $("#rev-add").addEventListener("click", () => {
+        const source = $("#rev-source").value.trim();
+        const amount = parseFloat($("#rev-amount").value);
+        const agentId = $("#rev-agent").value;
+        if (!source || !amount || amount <= 0) {
+            alert("Udfyld kilde og et positivt beløb.");
+            return;
+        }
+        state.revenue.unshift({ id: uid(), source, amount, agentId, date: new Date().toISOString() });
+        save();
+        $("#rev-source").value = "";
+        $("#rev-amount").value = "";
+        $("#rev-agent").value = "";
+        renderRevenue();
+        renderStats();
+    });
+
+    // ---------- Plan ----------
+    $("#plan-generate").addEventListener("click", async () => {
+        if (!state.apiKey) { $("#plan-status").textContent = "⚠ Tilføj API-nøgle under Opsæt."; return; }
+        const btn = $("#plan-generate");
+        const status = $("#plan-status");
+        const out = $("#plan-output");
+        btn.disabled = true;
+        status.textContent = "koordinerer agenter…";
+
+        const recent = state.vault.slice(0, 8).map(v => {
+            const a = AGENTS.find(x => x.id === v.agentId);
+            return `- [${a ? a.name : v.agentId}] ${v.content.slice(0, 400).replace(/\n/g, " ")}`;
+        }).join("\n");
+
+        const now = new Date();
+        const monthTotal = state.revenue
+            .filter(r => { const d = new Date(r.date); return d.getFullYear() === now.getFullYear() && d.getMonth() === now.getMonth(); })
+            .reduce((s, r) => s + r.amount, 0);
+
+        const brief = `Lav en konkret ugeplan mandag-søndag med dag-for-dag actions der rykker brugeren mod sit månedsmål.
+
+Brugerens profil: ${state.niche || "(ikke angivet)"}
+Månedsmål: ${state.goal} ${state.currency}
+Denne måned indtjent: ${monthTotal} ${state.currency}
+Mangler: ${Math.max(0, state.goal - monthTotal)} ${state.currency}
+
+Seneste agent-outputs (brug disse som input til planen):
+${recent || "(ingen endnu)"}
+
+Format:
+## Ugens fokus
+(1 sætning — det vigtigste)
+
+## Dag-for-dag
+- Mandag: …
+- Tirsdag: …
+- …
+
+## KPI for ugen
+- …
+
+## Hvad du IKKE skal lave
+- …
+
+Vær konkret. Ingen buzzwords. Nævn specifikke handlinger og tidsestimater.`;
+
+        try {
+            const content = await runAgent({
+                id: "strategy",
+                system: "Du er en kompromisløs executive coach for solo-operatører. Du laver ugeplaner der er brutalt konkrete og fokuserede på indtægt, ikke aktivitet. Svar på dansk."
+            }, brief);
+            out.innerHTML = renderMarkdown(content);
+            state.plans.unshift({ date: new Date().toISOString(), content });
+            if (state.plans.length > 10) state.plans = state.plans.slice(0, 10);
+            save();
+            status.textContent = "✓ plan klar";
+        } catch (err) {
+            status.textContent = "✗ fejl: " + err.message;
+        } finally {
+            btn.disabled = false;
+        }
+    });
+
+    function renderLatestPlan() {
+        if (state.plans.length) {
+            $("#plan-output").innerHTML = renderMarkdown(state.plans[0].content);
+        }
+    }
+
+    // ---------- Config ----------
+    function loadConfig() {
+        $("#cfg-api-key").value = state.apiKey;
+        $("#cfg-model").value = state.model;
+        $("#cfg-niche").value = state.niche;
+        $("#cfg-goal").value = state.goal;
+        $("#cfg-currency").value = state.currency;
+    }
+    $("#cfg-save").addEventListener("click", () => {
+        state.apiKey = $("#cfg-api-key").value.trim();
+        state.model = $("#cfg-model").value;
+        state.niche = $("#cfg-niche").value.trim();
+        state.goal = parseFloat($("#cfg-goal").value) || 0;
+        state.currency = ($("#cfg-currency").value || "kr").trim();
+        save();
+        renderStats();
+        renderRevenue();
+        alert("Gemt ✓");
+    });
+    $("#cfg-reset").addEventListener("click", () => {
+        if (!confirm("Nulstil ALT? Alle idéer, indtægter og config slettes.")) return;
+        localStorage.removeItem(STORAGE_KEY);
+        location.reload();
+    });
+
+    // ---------- Stats ----------
+    function renderStats() {
+        const earned = state.revenue.reduce((s, r) => s + r.amount, 0);
+        $("#stat-earned").textContent = fmt(earned);
+        $("#stat-ideas").textContent = state.vault.length;
+
+        // Pipeline = rough estimate: one idea worth ~500 kr average until realized
+        const pipeline = state.vault.length * 500;
+        $("#stat-pipeline").textContent = fmt(pipeline);
+    }
+
+    // ---------- Init ----------
+    renderAgents();
+    renderVault();
+    renderRevenueAgentSelect();
+    renderRevenue();
+    renderLatestPlan();
+    loadConfig();
+    renderStats();
+})();

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
     <div class="corner">
         <button id="lang-btn">EN</button>
         <button id="mute-btn">🔊</button>
+        <a href="agents.html" class="deck-link" title="Agent Deck — Money Management">💼</a>
     </div>
 
     <div class="overlay" id="overlay">

--- a/styles.css
+++ b/styles.css
@@ -145,6 +145,20 @@ html, body {
     min-width: 40px;
 }
 .corner button:active { background: rgba(127, 169, 216, 0.15); }
+.corner .deck-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    background: transparent;
+    border: 1px solid rgba(127, 169, 216, 0.25);
+    color: #7fa9d8;
+    padding: 6px 12px;
+    border-radius: 20px;
+    font-size: 13px;
+    min-width: 40px;
+}
+.corner .deck-link:active { background: rgba(127, 169, 216, 0.15); }
 
 .overlay {
     position: fixed;


### PR DESCRIPTION
## Summary
- Tilføjer Agent Deck: dashboard med 8 specialiserede AI-agenter (content, market, freelance, copy, product, SEO, automation, strategy) der genererer konkrete penge-muligheder via Claude API
- Idévault med søgning/eksport, indtægtstracker med månedsmål og progress-bar, ugeplan-generator
- Linker fra Jarvis-forsiden via 💼-ikon; API-nøgle arves automatisk fra Jarvis

## Test plan
- [ ] Åbn `/agents.html` på GitHub Pages
- [ ] Gå til Opsæt, indsæt Anthropic API-nøgle, beskriv niche og månedsmål
- [ ] Kør en agent og verificér output + at den gemmes i Idévault
- [ ] Log en indtægt og tjek at progress-bar + stats opdateres
- [ ] Generér ugeplan baseret på eksisterende idéer

https://claude.ai/code/session_01FeshENkKy4vUmqzDjsJ7uh